### PR TITLE
feat: Add ability to set environment variables via config

### DIFF
--- a/.adaptable/config.schema.json
+++ b/.adaptable/config.schema.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "environment": {
+            "type": "object",
+            "patternProperties": {
+                "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "environment": {
+            "$ref": "#/definitions/environment"
+        }
+    }
+}

--- a/common.ts
+++ b/common.ts
@@ -1,37 +1,8 @@
-import temp from "temp";
-import * as fs from "fs";
+import { EnvSimple } from "@adpt/cloud";
 import { loadAdaptableConfig } from "./template-support";
 
-temp.track();
-
-export interface GCloudConfig {
-    projectId: string;
-    creds: string;
-    region: string;
-}
-
 export interface Config {
-    gcloud: GCloudConfig;
-}
-
-function setupGCloud(config: GCloudConfig) {
-    process.env.CLOUDSDK_CORE_PROJECT = config.projectId;
-
-    let account;
-    try {
-        const key = JSON.parse(config.creds);
-        account = key.client_email;
-    } catch (err) {
-        throw new Error(`Error parsing gcloud.creds (must be JSON service account key file): ${err.message}`);
-    }
-    if (!account) throw new Error(`Invalid service account key JSON in gcloud.creds: "client_email" property not valid`);
-    process.env.CLOUDSDK_CORE_ACCOUNT = account;
-
-    const credsFile = temp.openSync({ prefix: "gcloud-creds-", suffix: ".json" });
-    fs.writeSync(credsFile.fd, config.creds);
-    fs.closeSync(credsFile.fd);
-    process.env.CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE = credsFile.path;
+    environment?: EnvSimple;
 }
 
 export const config = loadAdaptableConfig<Config>();
-if (config.gcloud) setupGCloud(config.gcloud);

--- a/index.tsx
+++ b/index.tsx
@@ -15,6 +15,7 @@ import Adapt, {
 import { mergeEnvSimple, useConnectTo } from "@adpt/cloud";
 import { DockerImageInstance } from "@adpt/cloud/docker";
 import { URL } from "url";
+import { config } from "./common";
 import { prodStyle } from "./styles";
 
 const {
@@ -39,7 +40,7 @@ function App() {
 
     const dbHand = handle();
     const dbEnv = useConnectTo(dbHand);
-    const env = mergeEnvSimple(dbEnv, { NODE_ENV: "production" });
+    const env = mergeEnvSimple(dbEnv, { NODE_ENV: "production" }, config.environment);
 
     return (
         <Group key="app">

--- a/index.tsx
+++ b/index.tsx
@@ -12,7 +12,7 @@ import Adapt, {
     useAsync,
     callInstanceMethod,
 } from "@adpt/core";
-import { mergeEnvSimple, useConnectTo } from "@adpt/cloud";
+import { EnvSimple, mergeEnvSimple, useConnectTo } from "@adpt/cloud";
 import { DockerImageInstance } from "@adpt/cloud/docker";
 import { URL } from "url";
 import { config } from "./common";
@@ -40,7 +40,13 @@ function App() {
 
     const dbHand = handle();
     const dbEnv = useConnectTo(dbHand);
-    const env = mergeEnvSimple(dbEnv, { NODE_ENV: "production" }, config.environment);
+    const externalHostname = `${appName}.${adaptableDomainName}`;
+    const standardEnv: EnvSimple = {
+        EXTERNAL_HOSTNAME: externalHostname,
+        EXTERNAL_URL: `https://${externalHostname}`,
+        NODE_ENV: "production",
+    };
+    const env = mergeEnvSimple(dbEnv, standardEnv, config.environment);
 
     return (
         <Group key="app">
@@ -81,7 +87,7 @@ function App() {
                 <HttpsLoadBalancer
                     key="lb"
                     appId={appId}
-                    hostname={`${appName}.${adaptableDomainName}`}
+                    hostname={externalHostname}
                     name="main"
                     target={ctrHost}
                     hostHeader={ctrHost}

--- a/package.json
+++ b/package.json
@@ -17,12 +17,10 @@
     "js-yaml": "^3.14.1",
     "json5": "^2.1.3",
     "source-map-support": "^0.5.19",
-    "temp": "^0.9.4",
     "typescript": "4.1.2"
   },
   "devDependencies": {
     "@types/json5": "^0.0.30",
-    "@types/temp": "^0.8.34",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,13 +367,6 @@
     "@types/minipass" "*"
     "@types/node" "*"
 
-"@types/temp@^0.8.34":
-  version "0.8.34"
-  resolved "https://registry.yarnpkg.com/@types/temp/-/temp-0.8.34.tgz#03e4b3cb67cbb48c425bbf54b12230fef85540ac"
-  integrity sha512-oLa9c5LHXgS6UimpEVp08De7QvZ+Dfu5bMQuWyMhf92Z26Q10ubEMOWy9OEfUdzW7Y/sDWVHmUaLFtmnX/2j0w==
-  dependencies:
-    "@types/node" "*"
-
 "@typescript-eslint/eslint-plugin@^2.30.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
@@ -2545,7 +2538,7 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
-rimraf@2.6.3, rimraf@~2.6.2:
+rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -2856,14 +2849,6 @@ tar@6.0.5:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
-
-temp@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
-  integrity sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
-  dependencies:
-    mkdirp "^0.5.1"
-    rimraf "~2.6.2"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Adds a JSON schema back into the template, so this also indirectly modifies the new app wizard flow to insert the configuration step. I suggest we modify that wizard to only show the configuration step if there are any **required** fields in the JSON schema so it doesn't show up for this template.

I did constrain the names of the allowed environment variables to be the restricted set of names that shells are guaranteed to support, as opposed to what a POSIX OS kernel will support. I can remove that and allow the foot gun if you prefer.

Also added two vars that tell the app what the hostname/URL is: `EXTERNAL_URL` and `EXTERNAL_HOSTNAME`. The naming on these is up for debate. I'd typically prefix with `ADAPTABLE_`, but if we're going to be integrating with a lot of open source template apps like this, maybe we want to try to use neutral names?