### PR TITLE
chore: Use @adaptable/cloud 0.0.22 for DATABASE_URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "cloud-run-with-sql",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Adaptable Cloud Run with Cloud SQL template",
   "author": "Manish Vachharajani <manishv@unbounded.systems>",
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/cloud": "^0.0.21",
+    "@adaptable/cloud": "^0.0.22",
     "@adpt/cloud": "^0.4.0-next.25",
     "@adpt/core": "^0.4.0-next.25",
     "@adpt/utils": "^0.4.0-next.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@adaptable/client@0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-0.0.20.tgz#8d4f736b4a9f58148cb3c695f7a6a390999b3cf2"
-  integrity sha512-hJIk+Z7Y8fUVo0nFJO1PiknVNrtJpnm3xwZgfGa77LEvwE1KXjbK1j7j0uy+up0+DjpyV9k/th0wHfPo5VLpKQ==
+"@adaptable/client@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-0.0.22.tgz#f7d9334da0adb0997afc595cca2ff720e72f6458"
+  integrity sha512-W+rwD1bMsvygLk2utFYW6vWts/15a2MCmnqgtKnDCtWcoGfhKTao4TMOJ+sKOkYUtyP+EoylEJinGyB+h1CZ4Q==
   dependencies:
-    "@adaptable/utils" "0.0.20"
+    "@adaptable/utils" "0.0.22"
     "@adobe/node-fetch-retry" "^1.1.1"
     "@adpt/utils" "0.4.0-next.25"
     "@feathersjs/authentication-client" "^4.5.7"
@@ -16,23 +16,24 @@
     fast-deep-equal "^3.1.3"
     lodash "^4.17.21"
     yup "^0.29.1"
-    zod "^3.0.0-alpha.4"
+    zod "^3.11.6"
 
-"@adaptable/cloud@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-0.0.20.tgz#2a2df9baa22257cd85a14592c5b96e3436938694"
-  integrity sha512-1ecduDIBB20pxV+fWCDSlt1al/xk1SJPbckKh1uwmV+QHXoGiTS/KArg8M7LXTiXIkkd6Z5IGVjNGvcL0KRRbA==
+"@adaptable/cloud@^0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-0.0.22.tgz#534f6e7790376017956dce3cecfa6f48ea495c88"
+  integrity sha512-A0/Rf3RYphawlaNLdisQeqBJ5eiLpKWhgASFUGPH1gdhd6OIZ+eMKCG1b6zH/u0oYub8KddugYnyGfgJDrj8+A==
   dependencies:
-    "@adaptable/client" "0.0.20"
-    "@adaptable/utils" "0.0.20"
+    "@adaptable/client" "0.0.22"
+    "@adaptable/utils" "0.0.22"
     "@adpt/utils" "^0.4.0-next.25"
     fast-deep-equal "^3.1.3"
     json-stable-stringify "^1.0.1"
+    lodash "^4.17.21"
 
-"@adaptable/utils@0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-0.0.20.tgz#6f126c914f032635fed23f57351c250e0a8a44ee"
-  integrity sha512-2wnPqS1Pcf5GLQ/6LLE4kEgr75MSUjaPACGfHYkzHx2+5GVCf+wM0UxC6hMMrpKO0iZp7W1XjaySv8HxPY9TvQ==
+"@adaptable/utils@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-0.0.22.tgz#bf5f72dc63f5f56ec091d709d927af5ab350a15c"
+  integrity sha512-RGybfQTbSjg+hhZwfu+imw50c2btaJ3xw399N6hab3LrzpBkC7pKdJNVYhuYOfR+pi9eMsUAfNCzjJCuPl1D3Q==
   dependencies:
     "@feathersjs/feathers" "^4.5.1"
 
@@ -3157,7 +3158,7 @@ zen-observable@^0.8.0:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zod@^3.0.0-alpha.4:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.0.2.tgz#0d8f0adbc7569e1a3c67b2cc788f81a55dc8a403"
-  integrity sha512-a+9VrxBi5CWBFq2LO5aNgbAaIRzPpBLbH4qGjSFeKd/ClLAXZq1dNFLTe9N1VDUBKxqXgHVkMlyp5MtSJylJww==
+zod@^3.11.6:
+  version "3.11.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.11.6.tgz#e43a5e0c213ae2e02aefe7cb2b1a6fa3d7f1f483"
+  integrity sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==


### PR DESCRIPTION
Bump @adaptable/cloud dependency to v0.0.22 so that the `Database` component will export a `DATABASE_URL` variable in addition to the protocol specific variables.