### PR TITLE
fix: Allow node-gyp builds by using full builder

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -56,7 +56,7 @@ function App() {
                 appId={appId}
                 config={{
                     type: "buildpack",
-                    builder: "paketobuildpacks/builder:base",
+                    builder: "paketobuildpacks/builder:full",
                 }}
                 imageName="appimage"
                 plan="hobby"


### PR DESCRIPTION
The `base` buildpack that we currently use does not support any NPM packages that use `node-gyp` to build because it lacks tools (primarily Python). The `full` builder has more tools installed and allows `node-gyp` builds to succeed. Tested on a sample Express app with `node-sass` ,which requires gyp.
