### PR TITLE
feat: Add config for project path, node scripts, and node version

### DIFF
--- a/.adaptable/config.schema.json
+++ b/.adaptable/config.schema.json
@@ -16,11 +16,23 @@
         "buildEnvironment": {
             "$ref": "#/definitions/environment"
         },
+        "databaseType": {
+            "enum": ["mssql", "mongodb"]
+        },
         "environment": {
             "$ref": "#/definitions/environment"
         },
-        "databaseType": {
-            "enum": ["mssql", "mongodb"]
+        "nodeRunScripts": {
+            "type": "string"
+        },
+        "nodeStartScript": {
+            "enum": ["start"]
+        },
+        "nodeVersion": {
+            "enum": ["12", "14", "16"]
+        },
+        "projectPath": {
+            "type": "string"
         }
     },
     "required": ["databaseType"]

--- a/common.ts
+++ b/common.ts
@@ -3,8 +3,12 @@ import { EnvSimple } from "@adpt/cloud";
 
 export interface Config {
     buildEnvironment?: EnvSimple;
-    environment?: EnvSimple;
     databaseType: "mongodb" | "mssql";
+    environment?: EnvSimple;
+    nodeRunScripts?: string;
+    nodeStartScript?: "start";
+    nodeVersion?: string;
+    projectPath?: string;
 }
 
 export const config = loadAdaptableAppConfig<Config>();

--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -14,8 +14,19 @@ if (appId == null) throw new Error("No ADAPTABLE_APP_ID found");
 const revId = process.env.ADAPTABLE_APPREVISION_ID;
 if (revId == null) throw new Error("No ADAPTABLE_APPREVISION_ID");
 
+// IMPORTANT: Update config.schema.json when the buildpack image changes
+// major Node versions.
 const buildpackImage = "paketobuildpacks/builder:0.2.6-full";
 module.exports.buildpackImage = buildpackImage;
+
+const userEnv = appConfig.buildEnvironment || {};
+const env = {
+    BP_NODE_PROJECT_PATH: appConfig.projectPath,
+    BP_NODE_RUN_SCRIPTS: appConfig.nodeRunScripts,
+    BP_NODE_VERSION: appConfig.nodeVersion,
+    // User can override the top level settings
+    ...userEnv,
+};
 
 /**
  * @type {import("@adaptable/client/dist/api-types/builds").CreateBuild}
@@ -26,7 +37,7 @@ const imageBuildProps = {
         type: "buildpack",
         builder: buildpackImage,
     },
-    env: appConfig.buildEnvironment,
+    env,
     imageName: "appimage",
     plan: "hobby",
     revId,


### PR DESCRIPTION
1. Adds config properties to align with the hard-coded `TemplateConfigDef`s in the new deploy workflow. None of the new top-level properties are required.
2. Uses these new top-level properties to set the buildpack's build environment variables: `BP_NODE_PROJECT_PATH`, appConfig.projectPath, `BP_NODE_RUN_SCRIPTS`, and `BP_NODE_VERSION`, but allows the users `buildEnvironment` to override those settings.
3. Enforces the only valid major Node versions that align to the specific version of buildpack in use (currently 12, 14, 16).