### PR TITLE
Fix double update that is required to clear certain deploy errors

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -6,12 +6,13 @@ import {
     HttpsLoadBalancer,
 } from "@adaptable/cloud";
 import Adapt, {
-    Group,
     handle,
     useMethod,
     useAsync,
     callInstanceMethod,
     useState,
+    Sequence,
+    PrimitiveComponent,
 } from "@adpt/core";
 import { EnvSimple, mergeEnvSimple, useConnectTo } from "@adpt/cloud";
 import { DockerImageInstance } from "@adpt/cloud/docker";
@@ -25,6 +26,8 @@ const { imageBuildProps } = require("./startup/buildInfo");
 const {
     adaptableDomainName, appId, appName,
 } = adaptableConfig();
+
+class Empty extends PrimitiveComponent {}
 
 function App() {
     const imgHand = handle<DockerImageInstance>();
@@ -58,7 +61,7 @@ function App() {
     const env = mergeEnvSimple(dbEnv, standardEnv, config.environment);
 
     return (
-        <Group key="app">
+        <Sequence key="app">
             <ContainerImage
                 key="app-img"
                 handle={imgHand}
@@ -74,7 +77,7 @@ function App() {
             />
             {imageStr && dbEnv ? (
                 <ContainerService
-                    key="app"
+                    key="app-ctr"
                     handle={ctrHand}
                     appId={appId}
                     env={env}
@@ -83,8 +86,7 @@ function App() {
                     plan="hobby"
                     port={80}
                 />
-            ) : null}
-
+            ) : <Empty key="app-ctr-empty" />}
             {ctrHost ? (
                 <HttpsLoadBalancer
                     key="lb"
@@ -94,8 +96,8 @@ function App() {
                     target={ctrHost}
                     hostHeader={ctrHost}
                 />
-            ) : null}
-        </Group>
+            ) : <Empty key="lb-empty" />}
+        </Sequence>
     );
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/cloud": "^1.2.0",
+    "@adaptable/cloud": "^1.4.0",
     "@adaptable/template": "^1.2.0",
     "@adpt/cloud": "^0.4.0-next.26",
     "@adpt/core": "^0.4.0-next.26",


### PR DESCRIPTION
If the main container fails to deploy (e.g., it is not correctly listening on `PORT`), it takes 2 additional deploys after the code is fixed for the error state to clear.  This fixes that issue by:

* Adding proper deploy dependencies between the components created by the starter
* Directly computing the image name so that an extra state-loop turn is not needed for the `ContainerService` to deploy the fixed image.
* Bumps `@adaptable/cloud` version to 1.4.0