### PR TITLE
Python support

### DIFF
--- a/.adaptable/config.schema.json
+++ b/.adaptable/config.schema.json
@@ -23,22 +23,28 @@
             "$ref": "#/definitions/environment"
         },
         "nodeRunScripts": {
-            "type": "string"
+            "type": "string",
+            "tags": ["nodejs"]
         },
         "nodeStartScript": {
-            "enum": ["start"]
+            "enum": ["start"],
+            "tags": ["nodejs"]
         },
         "nodeVersion": {
-            "enum": ["12", "14", "16"]
+            "enum": ["12", "14", "16"],
+            "tags": ["nodejs"]
         },
         "projectPath": {
-            "type": "string"
+            "type": "string",
+            "tags": ["nodejs"]
         },
         "pythonVersion": {
-            "enum": ["3.6", "3.7", "3.8", "3.9"]
+            "enum": ["3.6", "3.7", "3.8", "3.9"],
+            "tags": ["python"]
         },
         "startCommand": {
-            "type": "string"
+            "type": "string",
+            "tags": ["python"]
         }
     },
     "required": ["databaseType"]

--- a/.adaptable/config.schema.json
+++ b/.adaptable/config.schema.json
@@ -36,6 +36,9 @@
         },
         "pythonVersion": {
             "enum": ["3.6", "3.7", "3.8", "3.9"]
+        },
+        "startCommand": {
+            "type": "string"
         }
     },
     "required": ["databaseType"]

--- a/.adaptable/config.schema.json
+++ b/.adaptable/config.schema.json
@@ -33,6 +33,9 @@
         },
         "projectPath": {
             "type": "string"
+        },
+        "pythonVersion": {
+            "enum": ["3.6", "3.7", "3.8", "3.9"]
         }
     },
     "required": ["databaseType"]

--- a/common.ts
+++ b/common.ts
@@ -10,6 +10,7 @@ export interface Config {
     nodeVersion?: string;
     projectPath?: string;
     pythonVersion?: string;
+    startCommand?: string;
 }
 
 export const config = loadAdaptableAppConfig<Config>();

--- a/common.ts
+++ b/common.ts
@@ -9,6 +9,7 @@ export interface Config {
     nodeStartScript?: "start";
     nodeVersion?: string;
     projectPath?: string;
+    pythonVersion?: string;
 }
 
 export const config = loadAdaptableAppConfig<Config>();

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/cloud": "^1.7.0",
-    "@adaptable/template": "^1.2.0",
+    "@adaptable/cloud": "^1.10.0",
+    "@adaptable/template": "^1.10.0",
     "@adpt/cloud": "^0.4.0-next.26",
     "@adpt/core": "^0.4.0-next.26",
     "@adpt/utils": "^0.4.0-next.26",

--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -14,6 +14,8 @@ if (appId == null) throw new Error("No ADAPTABLE_APP_ID found");
 const revId = process.env.ADAPTABLE_APPREVISION_ID;
 if (revId == null) throw new Error("No ADAPTABLE_APPREVISION_ID");
 
+const tags = (process.env.ADAPTABLE_TEMPLATE_TAGS || "").split(",");
+
 // IMPORTANT: Update config.schema.json when the buildpack image changes
 // major Node versions.
 const buildpackImage = "paketobuildpacks/builder:0.2.6-full";

--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -24,6 +24,7 @@ const env = {
     BP_NODE_PROJECT_PATH: appConfig.projectPath,
     BP_NODE_RUN_SCRIPTS: appConfig.nodeRunScripts,
     BP_NODE_VERSION: appConfig.nodeVersion,
+    BP_CPYTHON_VERSION: appConfig.pythonVersion,
     // User can override the top level settings
     ...userEnv,
 };

--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -23,6 +23,8 @@ module.exports.buildpackImage = buildpackImage;
 
 const userEnv = appConfig.buildEnvironment || {};
 const env = {
+    // BP_LAUNCH_COMMAND is a JSON-format string
+    BP_LAUNCH_COMMAND: JSON.stringify(appConfig.startCommand),
     BP_NODE_PROJECT_PATH: appConfig.projectPath,
     BP_NODE_RUN_SCRIPTS: appConfig.nodeRunScripts,
     BP_NODE_VERSION: appConfig.nodeVersion,
@@ -46,3 +48,11 @@ const imageBuildProps = {
     revId,
 };
 module.exports.imageBuildProps = imageBuildProps;
+
+if (tags.includes("python")) {
+    imageBuildProps.config.buildpacks = [
+        "paketo-buildpacks/python",
+        // buildpack-launch is required for BP_LAUNCH_COMMAND
+        "adaptable/buildpack-launch:0.0.7",
+    ];
+}

--- a/startup/package.json
+++ b/startup/package.json
@@ -7,7 +7,7 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/client": "^1.7.0",
-    "@adaptable/template": "^1.2.0"
+    "@adaptable/client": "^1.10.0",
+    "@adaptable/template": "^1.10.0"
   }
 }

--- a/startup/yarn.lock
+++ b/startup/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@adaptable/client@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.7.0.tgz#6c32897f848efc23839d0a31aaa6a0a7253e56d4"
-  integrity sha512-L8ikelUYENzvDUDYl8Z71chP+x3ZmUlWkcHhKlqVQY54zJ1yS0ccOlgD2b12Td4VAnEfyIgPFDwLKy2LfP9XJw==
+"@adaptable/client@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.10.0.tgz#41157703f56c69877863cc1a36f70a8df4884f1a"
+  integrity sha512-UtWlsmfdpE8iXBHvuVJ7FODWPHPQ5ttDE60ExKkPWcct8L+KnBCZ5D6b8HyEH7+RV+IeWI4Yr73GRhlQpC6ycA==
   dependencies:
-    "@adaptable/utils" "1.7.0"
+    "@adaptable/utils" "1.10.0"
     "@adobe/node-fetch-retry" "^1.1.1"
     "@adpt/utils" "0.4.0-next.25"
     "@feathersjs/authentication-client" "^4.5.7"
@@ -18,22 +18,23 @@
     yup "^0.29.1"
     zod "^3.17.9"
 
-"@adaptable/template@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.2.0.tgz#889eb4c3206f8b84c4a4f8b923a35f94bbd70c18"
-  integrity sha512-jTxOp529d814XXvcAatpTBaFLGuVvOoGdwBA5tl35jVqr4bmQnDLMSbBUKvgacBvy59NhwzreKrFM0e3YB8QIQ==
+"@adaptable/template@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.10.0.tgz#92a80ebc7bac287262eade8f8fc7b0f67390a782"
+  integrity sha512-L4jKCLve7F/4yDkWZXtiliPogh4T1KxaMZ/cgVkTYODxrbmaxWv/RbzZdirSb3vpH5YOH0M/K5XMRwBr4u1/rQ==
   dependencies:
-    ajv "^7.0.3"
+    "@adaptable/utils" "1.10.0"
     dotenv "^8.2.0"
     js-yaml "^3.14.0"
     json5 "^2.1.3"
 
-"@adaptable/utils@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.7.0.tgz#40781bf007e25569283adf15918c98f6e50c36d7"
-  integrity sha512-+pSxvFA9ePb1Gnj0so3vEfsRbSA9aJees6ELMbnKCc9ebAa/Vhj+bu4T74a9Ktx0Ktt7pAtAnRIb8PYcwKGcDg==
+"@adaptable/utils@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.10.0.tgz#c9c7d645fc0572df6dd91ccf9d3cffd591d2e951"
+  integrity sha512-yRv4BX4vKxjMGAZZdTs07dYLGdIQyYvqhUaYRhRrX7jKXsgVB5kV712H0UZI2EQa80w+4jwB1qDIV6+6cZh/0Q==
   dependencies:
     "@feathersjs/feathers" "^4.5.1"
+    ajv "^7.0.3"
 
 "@adobe/node-fetch-retry@^1.1.1":
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@adaptable/client@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.7.0.tgz#6c32897f848efc23839d0a31aaa6a0a7253e56d4"
-  integrity sha512-L8ikelUYENzvDUDYl8Z71chP+x3ZmUlWkcHhKlqVQY54zJ1yS0ccOlgD2b12Td4VAnEfyIgPFDwLKy2LfP9XJw==
+"@adaptable/client@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.10.0.tgz#41157703f56c69877863cc1a36f70a8df4884f1a"
+  integrity sha512-UtWlsmfdpE8iXBHvuVJ7FODWPHPQ5ttDE60ExKkPWcct8L+KnBCZ5D6b8HyEH7+RV+IeWI4Yr73GRhlQpC6ycA==
   dependencies:
-    "@adaptable/utils" "1.7.0"
+    "@adaptable/utils" "1.10.0"
     "@adobe/node-fetch-retry" "^1.1.1"
     "@adpt/utils" "0.4.0-next.25"
     "@feathersjs/authentication-client" "^4.5.7"
@@ -18,34 +18,35 @@
     yup "^0.29.1"
     zod "^3.17.9"
 
-"@adaptable/cloud@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-1.7.0.tgz#30821b02de19edf3cfd04ed83b587cd5f8aa0b8b"
-  integrity sha512-FqznxMHTyQnT05EXjDKVmN90ta7TVp6GOTq70mpB4SwabkXKs73OQhHSz4fzi1q5jwHXejK0W7LAf4STpzXf3Q==
+"@adaptable/cloud@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-1.10.0.tgz#143e46a0cc3f04171f06da5b91528b6ecb85ccce"
+  integrity sha512-4+wgB647ofXYp6hZuBKjPUmveUywLK+VX/CeFll5NT7dWAD9uG6hTsBnnEF/nGMYkdt5nBQDT7iP5ItsiWB3Mg==
   dependencies:
-    "@adaptable/client" "1.7.0"
-    "@adaptable/utils" "1.7.0"
+    "@adaptable/client" "1.10.0"
+    "@adaptable/utils" "1.10.0"
     "@adpt/utils" "^0.4.0-next.25"
     fast-deep-equal "^3.1.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.21"
 
-"@adaptable/template@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.2.0.tgz#889eb4c3206f8b84c4a4f8b923a35f94bbd70c18"
-  integrity sha512-jTxOp529d814XXvcAatpTBaFLGuVvOoGdwBA5tl35jVqr4bmQnDLMSbBUKvgacBvy59NhwzreKrFM0e3YB8QIQ==
+"@adaptable/template@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.10.0.tgz#92a80ebc7bac287262eade8f8fc7b0f67390a782"
+  integrity sha512-L4jKCLve7F/4yDkWZXtiliPogh4T1KxaMZ/cgVkTYODxrbmaxWv/RbzZdirSb3vpH5YOH0M/K5XMRwBr4u1/rQ==
   dependencies:
-    ajv "^7.0.3"
+    "@adaptable/utils" "1.10.0"
     dotenv "^8.2.0"
     js-yaml "^3.14.0"
     json5 "^2.1.3"
 
-"@adaptable/utils@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.7.0.tgz#40781bf007e25569283adf15918c98f6e50c36d7"
-  integrity sha512-+pSxvFA9ePb1Gnj0so3vEfsRbSA9aJees6ELMbnKCc9ebAa/Vhj+bu4T74a9Ktx0Ktt7pAtAnRIb8PYcwKGcDg==
+"@adaptable/utils@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.10.0.tgz#c9c7d645fc0572df6dd91ccf9d3cffd591d2e951"
+  integrity sha512-yRv4BX4vKxjMGAZZdTs07dYLGdIQyYvqhUaYRhRrX7jKXsgVB5kV712H0UZI2EQa80w+4jwB1qDIV6+6cZh/0Q==
   dependencies:
     "@feathersjs/feathers" "^4.5.1"
+    ajv "^7.0.3"
 
 "@adobe/node-fetch-retry@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
**IMPORTANT:** Read the PR description for the `io` repo commits first.

**VERY IMPORTANT:** I'm proposing merging this into `v4` which is our current template. Take a **very** close look to ensure you also believe these changes won't break any existing apps.

The builder & buildpacks we use already support building Python. So these commits are really just for our configurability around Python.

The first three commits should be pretty self-explanatory if you've The last one (Allow `config.startCommand`) is a little more subtle. It uses the newly added `buildpacks` option to our `builds` service to both narrow which buildpacks to consider for use (of the buildpacks that are embedded within the builder) and to add one additional buildpack: the [Adaptable Launch Buildpack](https://github.com/adaptable/buildpack-launch), which is what uses `BP_LAUNCH_COMMAND` to set the image entrypoint.

In the future, we'll want to similarly narrow the building of Node images to only the nodejs buildpacks and probably to also add the Launch Buildpack to those builds too.
