### PR TITLE
Builder update, including major Python & Node versions

### DIFF
--- a/.adaptable/config.schema.json
+++ b/.adaptable/config.schema.json
@@ -31,7 +31,7 @@
             "tags": ["nodejs"]
         },
         "nodeVersion": {
-            "enum": ["12", "14", "16"],
+            "enum": ["12", "14", "16", "18"],
             "tags": ["nodejs"]
         },
         "projectPath": {
@@ -39,7 +39,7 @@
             "tags": ["nodejs"]
         },
         "pythonVersion": {
-            "enum": ["3.6", "3.7", "3.8", "3.9"],
+            "enum": ["3.6", "3.7", "3.8", "3.9", "3.10"],
             "tags": ["python"]
         },
         "startCommand": {

--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -48,6 +48,12 @@ const imageBuildProps = {
 };
 module.exports.imageBuildProps = imageBuildProps;
 
+if (tags.includes("nodejs")) {
+    imageBuildProps.config.buildpacks = [
+        "paketo-buildpacks/nodejs",
+    ];
+}
+
 if (tags.includes("python")) {
     if (appConfig.pythonVersion === "3.6") {
         imageBuildProps.config.builder = "paketobuildpacks/builder:0.2.6-full";

--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -17,9 +17,8 @@ if (revId == null) throw new Error("No ADAPTABLE_APPREVISION_ID");
 const tags = (process.env.ADAPTABLE_TEMPLATE_TAGS || "").split(",");
 
 // IMPORTANT: Update config.schema.json when the buildpack image changes
-// major Node versions.
-const buildpackImage = "paketobuildpacks/builder:0.2.6-full";
-module.exports.buildpackImage = buildpackImage;
+// Node/Python versions.
+const defaultBuilderImage = "paketobuildpacks/builder:0.2.182-full";
 
 const userEnv = appConfig.buildEnvironment || {};
 const env = {
@@ -40,7 +39,7 @@ const imageBuildProps = {
     appId,
     config: {
         type: "buildpack",
-        builder: buildpackImage,
+        builder: defaultBuilderImage,
     },
     env,
     imageName: "appimage",
@@ -50,6 +49,10 @@ const imageBuildProps = {
 module.exports.imageBuildProps = imageBuildProps;
 
 if (tags.includes("python")) {
+    if (appConfig.pythonVersion === "3.6") {
+        imageBuildProps.config.builder = "paketobuildpacks/builder:0.2.6-full";
+    }
+
     imageBuildProps.config.buildpacks = [
         "paketo-buildpacks/python",
         // buildpack-launch is required for BP_LAUNCH_COMMAND


### PR DESCRIPTION
# Summary

This PR updates the base builder for the template, including build image OS updates and significant version updates for Node and Python.

It also fixes two bugs affecting users:
- A bug with Node apps detecting as other languages.
- A bug where Poetry+Python apps don't detect as Python.

This is a template version change (merging to new `v5 branch) because the build OS updates and Node/Python feature/patch version updates could create breakages for users, so the template version allows users to be migrated deliberately (and slowly).

Note: This does not fix the bug where Pip+Python apps don't detect as Python. We're waiting on [this bug](https://github.com/paketo-buildpacks/python-start/issues/196) to get fixed for that.

# Builder updates

The default builder version goes from [0.2.6](https://github.com/paketo-buildpacks/full-builder/releases/tag/v0.2.6) to [0.2.182](https://github.com/paketo-buildpacks/full-builder/releases/tag/v0.2.182).

# Node versions

This adds support for Node 18 and does not drop support for any major Node versions. Minor/patch versions of all Node versions are updated.

# Python versions

This adds support for Python 3.10 and does not drop support for any minor Python versions. Patch versions of all Python versions are updated. Note that using Python 3.6 results in using the older build image as the newer build image has dropped support for the EOL Python 3.6 release. We can drop 3.6 support once we've verified no customers are using it.