### PR TITLE
Workaround for Python apps without top level *.py files not detecting during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/cloud": "^1.10.0",
-    "@adaptable/template": "^1.10.0",
+    "@adaptable/cloud": "^1.12.0",
+    "@adaptable/template": "^1.11.0",
     "@adpt/cloud": "^0.4.0-next.26",
     "@adpt/core": "^0.4.0-next.26",
     "@adpt/utils": "^0.4.0-next.26",

--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -49,10 +49,21 @@ const imageBuildProps = {
 };
 module.exports.imageBuildProps = imageBuildProps;
 
+// This works around the following issues:
+//   https://github.com/paketo-buildpacks/python-start/issues/196
+//   https://github.com/paketo-buildpacks/python-start/pull/128
+// When we update to a version that has both of these fixes integrated,
+// this workaround can be removed.
+const pythonWorkaround = `#!/bin/sh
+
+touch __adaptable.py
+`;
+
 if (tags.includes("python")) {
     imageBuildProps.config.buildpacks = [
         "paketo-buildpacks/python",
         // buildpack-launch is required for BP_LAUNCH_COMMAND
         "adaptable/buildpack-launch:0.0.7",
     ];
+    imageBuildProps.config.preBuildScript = pythonWorkaround;
 }

--- a/startup/package.json
+++ b/startup/package.json
@@ -7,7 +7,7 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/client": "^1.10.0",
-    "@adaptable/template": "^1.10.0"
+    "@adaptable/client": "^1.12.0",
+    "@adaptable/template": "^1.11.0"
   }
 }

--- a/startup/yarn.lock
+++ b/startup/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@adaptable/client@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.10.0.tgz#41157703f56c69877863cc1a36f70a8df4884f1a"
-  integrity sha512-UtWlsmfdpE8iXBHvuVJ7FODWPHPQ5ttDE60ExKkPWcct8L+KnBCZ5D6b8HyEH7+RV+IeWI4Yr73GRhlQpC6ycA==
+"@adaptable/client@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.12.0.tgz#5287656e2a58a7dcd54daed4d7abb98cca3490f8"
+  integrity sha512-eJkRxsqlcv2LAEnlrTbePiJPktaW62A0lgBzh1xcpPKv5dtBmDus3YuCSqqRYOzlC+e6oA/QsOF+fF+9Intbhg==
   dependencies:
-    "@adaptable/utils" "1.10.0"
+    "@adaptable/utils" "1.11.0"
     "@adobe/node-fetch-retry" "^1.1.1"
     "@adpt/utils" "0.4.0-next.25"
     "@feathersjs/authentication-client" "^4.5.7"
@@ -18,20 +18,20 @@
     yup "^0.29.1"
     zod "^3.17.9"
 
-"@adaptable/template@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.10.0.tgz#92a80ebc7bac287262eade8f8fc7b0f67390a782"
-  integrity sha512-L4jKCLve7F/4yDkWZXtiliPogh4T1KxaMZ/cgVkTYODxrbmaxWv/RbzZdirSb3vpH5YOH0M/K5XMRwBr4u1/rQ==
+"@adaptable/template@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.11.0.tgz#34ad1c82e2c87a9045b8c3cce3a47b6d68438556"
+  integrity sha512-oeZuxOfnBVFKCFwVmjuYpYjIfvYu/QfF8mCyQhcRYrrDg6zalkBgV+RH+bt49Tsq8P4k1xDrpTLb6L7LkCurvg==
   dependencies:
-    "@adaptable/utils" "1.10.0"
+    "@adaptable/utils" "1.11.0"
     dotenv "^8.2.0"
     js-yaml "^3.14.0"
     json5 "^2.1.3"
 
-"@adaptable/utils@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.10.0.tgz#c9c7d645fc0572df6dd91ccf9d3cffd591d2e951"
-  integrity sha512-yRv4BX4vKxjMGAZZdTs07dYLGdIQyYvqhUaYRhRrX7jKXsgVB5kV712H0UZI2EQa80w+4jwB1qDIV6+6cZh/0Q==
+"@adaptable/utils@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.11.0.tgz#23a1aa5dee0cd819e3ae4a37650c0f3eb4d46754"
+  integrity sha512-Wml2gxmTJq6v/+Sgi+4BcPI9eS5A7TQLHsBGSQC/X84nIubpVGzZ3SpppkX+xi9vMvJst5W7a1O97jG+4BaMLA==
   dependencies:
     "@feathersjs/feathers" "^4.5.1"
     ajv "^7.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@adaptable/client@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.10.0.tgz#41157703f56c69877863cc1a36f70a8df4884f1a"
-  integrity sha512-UtWlsmfdpE8iXBHvuVJ7FODWPHPQ5ttDE60ExKkPWcct8L+KnBCZ5D6b8HyEH7+RV+IeWI4Yr73GRhlQpC6ycA==
+"@adaptable/client@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.12.0.tgz#5287656e2a58a7dcd54daed4d7abb98cca3490f8"
+  integrity sha512-eJkRxsqlcv2LAEnlrTbePiJPktaW62A0lgBzh1xcpPKv5dtBmDus3YuCSqqRYOzlC+e6oA/QsOF+fF+9Intbhg==
   dependencies:
-    "@adaptable/utils" "1.10.0"
+    "@adaptable/utils" "1.11.0"
     "@adobe/node-fetch-retry" "^1.1.1"
     "@adpt/utils" "0.4.0-next.25"
     "@feathersjs/authentication-client" "^4.5.7"
@@ -18,32 +18,32 @@
     yup "^0.29.1"
     zod "^3.17.9"
 
-"@adaptable/cloud@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-1.10.0.tgz#143e46a0cc3f04171f06da5b91528b6ecb85ccce"
-  integrity sha512-4+wgB647ofXYp6hZuBKjPUmveUywLK+VX/CeFll5NT7dWAD9uG6hTsBnnEF/nGMYkdt5nBQDT7iP5ItsiWB3Mg==
+"@adaptable/cloud@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-1.12.0.tgz#c77899deb0f59ee2674ac6f269ef398d72318355"
+  integrity sha512-A3TDg94gta3nsBp5XYEAT3d7sX0eqzvwC0I8B2py1Bc8j3Ji+244KLCsGVLDVxzFSJ87U+4FiiUpXDim/euTPA==
   dependencies:
-    "@adaptable/client" "1.10.0"
-    "@adaptable/utils" "1.10.0"
+    "@adaptable/client" "1.12.0"
+    "@adaptable/utils" "1.11.0"
     "@adpt/utils" "^0.4.0-next.25"
     fast-deep-equal "^3.1.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.21"
 
-"@adaptable/template@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.10.0.tgz#92a80ebc7bac287262eade8f8fc7b0f67390a782"
-  integrity sha512-L4jKCLve7F/4yDkWZXtiliPogh4T1KxaMZ/cgVkTYODxrbmaxWv/RbzZdirSb3vpH5YOH0M/K5XMRwBr4u1/rQ==
+"@adaptable/template@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.11.0.tgz#34ad1c82e2c87a9045b8c3cce3a47b6d68438556"
+  integrity sha512-oeZuxOfnBVFKCFwVmjuYpYjIfvYu/QfF8mCyQhcRYrrDg6zalkBgV+RH+bt49Tsq8P4k1xDrpTLb6L7LkCurvg==
   dependencies:
-    "@adaptable/utils" "1.10.0"
+    "@adaptable/utils" "1.11.0"
     dotenv "^8.2.0"
     js-yaml "^3.14.0"
     json5 "^2.1.3"
 
-"@adaptable/utils@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.10.0.tgz#c9c7d645fc0572df6dd91ccf9d3cffd591d2e951"
-  integrity sha512-yRv4BX4vKxjMGAZZdTs07dYLGdIQyYvqhUaYRhRrX7jKXsgVB5kV712H0UZI2EQa80w+4jwB1qDIV6+6cZh/0Q==
+"@adaptable/utils@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.11.0.tgz#23a1aa5dee0cd819e3ae4a37650c0f3eb4d46754"
+  integrity sha512-Wml2gxmTJq6v/+Sgi+4BcPI9eS5A7TQLHsBGSQC/X84nIubpVGzZ3SpppkX+xi9vMvJst5W7a1O97jG+4BaMLA==
   dependencies:
     "@feathersjs/feathers" "^4.5.1"
     ajv "^7.0.3"


### PR DESCRIPTION
> *DONE*: The corresponding [API pull request](https://github.com/adaptable/io/pull/682) needs to be merged to prod first. I'll also publish @adaptable packages and update the versions in the template before merging.

# Description

This change works around the bug in adaptable/io#648. It uses the builds service's new `preBuildScript` functionality to run a script that just touches a `.py` file in the repo root. While it's technically possible that there could be apps that have some issue with an extra `.py` file, the probability seems pretty remote compared to the high percentage of Python app users we've had that can't build their app on Adaptable at all. So it's a risk and a tradeoff. Once the upstream buildpacks have been fixed, the workaround can be removed from the template.

## Merge ordering

Please review the [API PR](https://github.com/adaptable/io/pull/682) and this one together and approve if/when they look OK, but don't merge.
I need to merge the API change to prod first, then merge the template.

## Testing

I've manually tested that this fixes the issue and run CI with the template pointing to this branch that has the template fix.
