### PR TITLE
fix: Nixpacks images need HOME set correctly

### DIFF
--- a/startup/buildInfo.js
+++ b/startup/buildInfo.js
@@ -146,6 +146,10 @@ function nixpacksBuilder(appConfig, tags) {
     const variables = stripUndef({
         NIXPACKS_NODE_VERSION: appConfig.nodeVersion,
         NIXPACKS_PYTHON_VERSION: appConfig.pythonVersion,
+        // Ensure HOME is set correctly. The built image doesn't seem to contain
+        // an explicit setting and Kubernetes' runtime seems to default to
+        // using /home, which is different from Docker which defaults to /root.
+        HOME: "/root",
     });
 
     /**


### PR DESCRIPTION
Nixpacks images are highly dependent on correct execution of the user's (root's) `.profile` and related scripts to correctly set up paths and such. But the image doesn't seem to explicitly set `HOME`. From what I can gather, the Kubernetes runtime ends up setting this to `/home`, which is incorrect and results in the image not running correctly. (Note that the Docker runtime sets it to `/root`.)

Explicitly setting it in the built image seems to be best practice, so let's do that.
