### PR TITLE
fix: Adaptable root certs are at wrong path for Nixpacks and Dockerfile builders

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -26,7 +26,10 @@ import { config, ConfigDomains } from "./common";
 import { prodStyle } from "./styles";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { imageBuildProps } = require("./startup/buildInfo");
+const { adaptEnv, imageBuildProps } = require("./startup/buildInfo");
+
+// Apply adaptEnv to the current process environment
+Object.assign(process.env, adaptEnv || {});
 
 const {
     adaptableDomainName, appId, appName,

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/cloud": "1.26.0",
-    "@adaptable/template": "1.26.0",
+    "@adaptable/cloud": "1.27.0",
+    "@adaptable/template": "1.27.0",
     "@adpt/cloud": "^0.4.0-next.26",
     "@adpt/core": "^0.4.0-next.26",
     "@adpt/utils": "^0.4.0-next.26",

--- a/startup/package.json
+++ b/startup/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "@adaptable/client": "^1.26.0",
-    "@adaptable/template": "^1.26.0"
+    "@adaptable/template": "^1.26.0",
+    "@adaptable/utils": "^1.26.0"
   }
 }

--- a/startup/package.json
+++ b/startup/package.json
@@ -7,8 +7,8 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
-    "@adaptable/client": "^1.26.0",
-    "@adaptable/template": "^1.26.0",
-    "@adaptable/utils": "^1.26.0"
+    "@adaptable/client": "^1.27.0",
+    "@adaptable/template": "^1.27.0",
+    "@adaptable/utils": "^1.27.0"
   }
 }

--- a/startup/yarn.lock
+++ b/startup/yarn.lock
@@ -2,14 +2,13 @@
 # yarn lockfile v1
 
 
-"@adaptable/client@^1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.26.0.tgz#9e7a9f8302ccdea6c90028d12927565332bcd617"
-  integrity sha512-aAGb3RokTFYJeHRqjqeVN2aBFUpdW/yWQkmK5NwA3c5oIlFQPzPwwb+2js0mWsz2GY/XRtXEDjkSf8IMvj0+4A==
+"@adaptable/client@^1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.27.0.tgz#35fb880195d4bdc0e4171ea12f1b1c4087c4c434"
+  integrity sha512-17ErMVK1yJvIsJEbBp2JtCdRsJcQc/XkDKiPGoupKIEM64qakG2GvClU3ucGShdcYurU8dJR5zgR0KpLtfUAmA==
   dependencies:
-    "@adaptable/utils" "1.26.0"
+    "@adaptable/utils" "1.27.0"
     "@adobe/node-fetch-retry" "^1.1.1"
-    "@adpt/utils" "0.4.0-next.25"
     "@feathersjs/authentication-client" "^4.5.15"
     "@feathersjs/feathers" "^4.5.15"
     "@feathersjs/rest-client" "^4.5.15"
@@ -20,20 +19,20 @@
     yup "^1.0.0-beta.8"
     zod "^3.22.1"
 
-"@adaptable/template@^1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.26.0.tgz#714fc49a8f9d905ded951e31e684a300fb026b73"
-  integrity sha512-fD6ie0HE5KD2SAcGT2OHXWEt+IkQPOZeGoR5taDxX51AkOBZeHwSGG6/fSTGNIXFg24k/KNqoWvMcTrQCYuK0g==
+"@adaptable/template@^1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.27.0.tgz#a82e4e2ac0c8af2383b781d625d6e6946b919fa4"
+  integrity sha512-w25kJ7RTOM66XEBq9eFQjRtuxG4rDf2DBbelEBMP6dz55sVO5FrceEfb6WXNXySMxl5d2f6KB+snVKX7+lDPbA==
   dependencies:
-    "@adaptable/utils" "1.26.0"
+    "@adaptable/utils" "1.27.0"
     dotenv "^8.2.0"
     js-yaml "^3.14.0"
     json5 "^2.1.3"
 
-"@adaptable/utils@1.26.0", "@adaptable/utils@^1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.26.0.tgz#c30cf3370e663d78a65a832654c12535bf79ac41"
-  integrity sha512-7MhUT+iIAlXglToIeihOlsLEO37mPU2Nr+G9tLLKZPi557svy/ZwSh8K1Y+5rbCPQ5r2QsxKuZCW/e9oL4myHw==
+"@adaptable/utils@1.27.0", "@adaptable/utils@^1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.27.0.tgz#dd87ac7b3cea42d1ed7ec52770ae6d0010197053"
+  integrity sha512-kJjglcjluo5KekgUSaG/8qvnj3XQH32+MpbgnmYaEG+6ghchvZSKn2ZfWV93atvf3nkDIK8Kdgg9BfILDmM2gA==
   dependencies:
     "@feathersjs/feathers" "^4.5.15"
     ajv "^8.12.0"
@@ -48,39 +47,6 @@
   dependencies:
     abort-controller "^3.0.0"
     node-fetch "^2.6.1"
-
-"@adpt/utils@0.4.0-next.25":
-  version "0.4.0-next.25"
-  resolved "https://registry.yarnpkg.com/@adpt/utils/-/utils-0.4.0-next.25.tgz#8f425e10f5026b3fa8bd9a8255a916760e8a08a1"
-  integrity sha512-PX0gj52w9sGW9PTzh1tmlusEcHA1YmICMdRiYp4C+B0RtFLHlUe1vKuZT9e1sdgbUmhyY3M90mCj7gkQjs2A6w==
-  dependencies:
-    "@types/debug" "4.1.5"
-    "@types/fs-extra" "8.1.1"
-    "@types/jju" "1.4.1"
-    "@types/tar" "4.0.4"
-    "@unboundedsystems/node-graceful" "3.0.0-unb.2"
-    "@usys/collections-ts" "0.0.2"
-    capture-exit "2.0.0"
-    debug "4.3.1"
-    decamelize "4.0.0"
-    deep-diff "1.0.2"
-    eventemitter2 "6.4.3"
-    execa "5.0.0"
-    find-up "5.0.0"
-    fs-extra "9.0.1"
-    global-dirs "2.0.1"
-    jju "1.4.0"
-    json-stable-stringify "1.0.1"
-    json5-with-undefined "2.1.301"
-    lodash "4.17.20"
-    node-fetch "2.6.1"
-    npm-run-path "4.0.1"
-    p-defer "3.0.0"
-    tar "6.0.5"
-    ts-custom-error "3.2.0"
-    tslib "2.0.3"
-    type-ops "3.0.3"
-    yarn "1.22.10"
 
 "@feathersjs/authentication-client@^4.5.15":
   version "4.5.16"
@@ -238,23 +204,6 @@
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.4.tgz#1326429a519cc077028150343fd502b04686bd6f"
   integrity sha512-2in/lrHRNmDvHPgyormtEralhPcN3An1gLjJzj2Bw145VBxkQ75JEXW6CTdMAwShiHQcYsl2d10IjQSdJSJz4g==
 
-"@types/debug@4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
-  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
-
-"@types/fs-extra@8.1.1":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.1.tgz#1e49f22d09aa46e19b51c0b013cb63d0d923a068"
-  integrity sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
-  dependencies:
-    "@types/node" "*"
-
-"@types/jju@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@types/jju/-/jju-1.4.1.tgz#0a39f5f8e84fec46150a7b9ca985c3f89ad98e9f"
-  integrity sha512-LFt+YA7Lv2IZROMwokZKiPNORAV5N3huMs3IKnzlE430HWhWYZ8b+78HiwJXJJP1V2IEjinyJURuRJfGoaFSIA==
-
 "@types/jsonwebtoken@^9.0.0":
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#9eeb56c76dd555039be2a3972218de5bd3b8d83e"
@@ -266,13 +215,6 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
-
-"@types/minipass@*":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-3.1.2.tgz#e2d7f9df0698aff421dcf145b4fc05b8183b9030"
-  integrity sha512-foLGjgrJkUjLG/o2t2ymlZGEoBNBa/TfoUZ7oCTkOjP1T43UGBJspovJou/l3ZuHvye2ewR5cZNtp2zyWgILMA==
-  dependencies:
-    "@types/node" "*"
 
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "17.0.13"
@@ -289,30 +231,10 @@
     "@types/tough-cookie" "*"
     form-data "^2.5.0"
 
-"@types/tar@4.0.4":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.4.tgz#d680de60855e7778a51c672b755869a3b8d2889f"
-  integrity sha512-0Xv+xcmkTsOZdIF4yCnd7RkOOyfyqPaqJ7RZFKnwdxfDbkN3eAAE9sHl8zJFqBz4VhxolW9EErbjR1oyH7jK2A==
-  dependencies:
-    "@types/minipass" "*"
-    "@types/node" "*"
-
 "@types/tough-cookie@*":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.4.tgz#cf2f0c7c51b985b6afecea73eb2cd65421ecb717"
   integrity sha512-95Sfz4nvMAb0Nl9DTxN3j64adfwfbBPEYq14VN7zT5J5O2M9V6iZMIIQU1U+pJyl9agHYHNCqhCXgyEtIRRa5A==
-
-"@unboundedsystems/node-graceful@3.0.0-unb.2":
-  version "3.0.0-unb.2"
-  resolved "https://registry.yarnpkg.com/@unboundedsystems/node-graceful/-/node-graceful-3.0.0-unb.2.tgz#103c398104deaf7b4aa33c005f3fa3fee03c8c01"
-  integrity sha512-3riqB13DcaChIAHY1c8VgnDODAhpevMvacZEVt0GNxWV1gl5hvKWUSSAtnuPNfuoLn6dhXhREGg+TxDD5M4tAg==
-
-"@usys/collections-ts@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@usys/collections-ts/-/collections-ts-0.0.2.tgz#11a6144654743603d6395ceba21a63bbce3a319c"
-  integrity sha512-DV/8naszTbt/wDB3SGptMTK2aOjxlcLJP83Ft+mAItinfojyJajEfL9Y1FFhFBv8hcHTC+irlzzHueWXbKEBBw==
-  dependencies:
-    collections "^5.1.5"
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -376,11 +298,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
 base64-js@^1.3.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -404,18 +321,6 @@ call-bind@^1.0.0:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-capture-exit@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
-  integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
-  dependencies:
-    rsvp "^4.8.4"
-
-chownr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
-  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
-
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
@@ -424,13 +329,6 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
-
-collections@^5.1.5:
-  version "5.1.13"
-  resolved "https://registry.yarnpkg.com/collections/-/collections-5.1.13.tgz#eee204a93b67473c8e74e00e934a997cc2817585"
-  integrity sha512-SCb6Qd+d3Z02corWQ7/mqXiXeeTdHvkP6TeFSYfGYdCFp1WrjSNZ3j6y8Y3T/7osGEe0iOcU2g1d346l99m4Lg==
-  dependencies:
-    weak-map "~1.0.x"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -451,38 +349,12 @@ combined-stream@^1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-cross-spawn@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
 debug@4, debug@^4.1.1, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
-
-debug@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-decamelize@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
-  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
-
-deep-diff@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
-  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -538,30 +410,10 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-eventemitter2@6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.3.tgz#35c563619b13f3681e7eb05cbdaf50f56ba58820"
-  integrity sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==
-
 events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
-
-execa@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
-  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
-  dependencies:
-    cross-spawn "^7.0.3"
-    get-stream "^6.0.0"
-    human-signals "^2.1.0"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.1"
-    onetime "^5.1.2"
-    signal-exit "^3.0.3"
-    strip-final-newline "^2.0.0"
 
 extend@^3.0.2:
   version "3.0.2"
@@ -581,14 +433,6 @@ fetch-cookie@^2.1.0:
     set-cookie-parser "^2.4.8"
     tough-cookie "^4.0.0"
 
-find-up@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
 form-data@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
@@ -597,23 +441,6 @@ form-data@^2.5.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-fs-extra@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
-  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
-
-fs-minipass@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
-  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
-  dependencies:
-    minipass "^3.0.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -652,18 +479,6 @@ get-intrinsic@^1.0.2:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-get-stream@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
-  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
-
-global-dirs@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.0.1.tgz#acdf3bb6685bcd55cb35e8a052266569e9469201"
-  integrity sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==
-  dependencies:
-    ini "^1.3.5"
-
 google-auth-library@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.1.0.tgz#5c8444ca5c298030bbd7535f13b84748a86a8091"
@@ -693,11 +508,6 @@ google-gax@^4.0.3:
     proto3-json-serializer "^2.0.0"
     protobufjs "7.2.5"
     retry-request "^7.0.0"
-
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.9"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
-  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 gtoken@^7.0.0:
   version "7.0.1"
@@ -744,20 +554,10 @@ https-proxy-agent@^7.0.1:
     agent-base "^7.0.2"
     debug "4"
 
-human-signals@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
-  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
-
 inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-ini@^1.3.5:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
-  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -768,16 +568,6 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-jju@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
-  integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=
 
 js-yaml@^3.14.0:
   version "3.14.1"
@@ -799,38 +589,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-stable-stringify@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
-json5-with-undefined@2.1.301:
-  version "2.1.301"
-  resolved "https://registry.yarnpkg.com/json5-with-undefined/-/json5-with-undefined-2.1.301.tgz#3d32fe22b47065fc6350ed3af5a4b3863394e760"
-  integrity sha512-GUI3FVAk5bJfh5yzjoqd82RebCIEBVFcqmLfoEGcaZulyMpqnqDm35GhX9zPakrU0/IS9m4PClmpofetg55Tvw==
-  dependencies:
-    minimist "^1.2.5"
-
 json5@^2.1.3:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
-
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonwebtoken@^9.0.0:
   version "9.0.0"
@@ -876,22 +638,10 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
-
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
-
-lodash@4.17.20:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lodash@^4.17.21:
   version "4.17.21"
@@ -915,11 +665,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-merge-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
-  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
-
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -932,36 +677,6 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-mimic-fn@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
-  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minipass@^3.0.0:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
-  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
-  dependencies:
-    yallist "^4.0.0"
-
-minizlib@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
-  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
-
-mkdirp@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -972,24 +687,12 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
 node-fetch@^2.6.1, node-fetch@^2.6.9:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
-
-npm-run-path@4.0.1, npm-run-path@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
-  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
-  dependencies:
-    path-key "^3.0.0"
 
 object-hash@^3.0.0:
   version "3.0.0"
@@ -1007,42 +710,6 @@ once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
-
-onetime@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
-  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
-  dependencies:
-    mimic-fn "^2.1.0"
-
-p-defer@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
-  integrity sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
-
-p-limit@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
-
-path-exists@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
-  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-path-key@^3.0.0, path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
-  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 property-expr@^2.0.5:
   version "2.0.5"
@@ -1135,11 +802,6 @@ retry-request@^7.0.0:
     extend "^3.0.2"
     teeny-request "^9.0.0"
 
-rsvp@^4.8.4:
-  version "4.8.5"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
-  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
-
 safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -1157,18 +819,6 @@ set-cookie-parser@^2.4.8:
   resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
   integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
-  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
-  dependencies:
-    shebang-regex "^3.0.0"
-
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
-  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -1177,11 +827,6 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
-
-signal-exit@^3.0.3:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
-  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1223,27 +868,10 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-final-newline@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
-  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-
 stubs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==
-
-tar@6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
-  integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^3.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
 
 teeny-request@^9.0.0:
   version "9.0.0"
@@ -1281,25 +909,10 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-ts-custom-error@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.2.0.tgz#ff8f80a3812bab9dc448536312da52dce1b720fb"
-  integrity sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A==
-
-tslib@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
-
 type-fest@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
-
-type-ops@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/type-ops/-/type-ops-3.0.3.tgz#fbcce4129e0f3f10975732ad8bdc7798824d593a"
-  integrity sha512-ox+din2lhO8UmQ83rwPvsmuAvz85oAD9VeiQMnoBeXRD+a0kB6EEyS4kVaunmdj6V9QYGs9yhMpZb+Muma7UZA==
 
 uberproto@^2.0.6:
   version "2.0.6"
@@ -1310,16 +923,6 @@ universalify@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
-universalify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
-  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
-
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -1351,11 +954,6 @@ uuid@^9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
-weak-map@~1.0.x:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
-  integrity sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=
-
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -1368,13 +966,6 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
-
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -1417,16 +1008,6 @@ yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
-
-yarn@1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
-
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
-  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 yup@^1.0.0-beta.8:
   version "1.1.1"

--- a/startup/yarn.lock
+++ b/startup/yarn.lock
@@ -30,7 +30,7 @@
     js-yaml "^3.14.0"
     json5 "^2.1.3"
 
-"@adaptable/utils@1.26.0":
+"@adaptable/utils@1.26.0", "@adaptable/utils@^1.26.0":
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.26.0.tgz#c30cf3370e663d78a65a832654c12535bf79ac41"
   integrity sha512-7MhUT+iIAlXglToIeihOlsLEO37mPU2Nr+G9tLLKZPi557svy/ZwSh8K1Y+5rbCPQ5r2QsxKuZCW/e9oL4myHw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,13 @@
 # yarn lockfile v1
 
 
-"@adaptable/client@1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.26.0.tgz#9e7a9f8302ccdea6c90028d12927565332bcd617"
-  integrity sha512-aAGb3RokTFYJeHRqjqeVN2aBFUpdW/yWQkmK5NwA3c5oIlFQPzPwwb+2js0mWsz2GY/XRtXEDjkSf8IMvj0+4A==
+"@adaptable/client@1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/client/-/client-1.27.0.tgz#35fb880195d4bdc0e4171ea12f1b1c4087c4c434"
+  integrity sha512-17ErMVK1yJvIsJEbBp2JtCdRsJcQc/XkDKiPGoupKIEM64qakG2GvClU3ucGShdcYurU8dJR5zgR0KpLtfUAmA==
   dependencies:
-    "@adaptable/utils" "1.26.0"
+    "@adaptable/utils" "1.27.0"
     "@adobe/node-fetch-retry" "^1.1.1"
-    "@adpt/utils" "0.4.0-next.25"
     "@feathersjs/authentication-client" "^4.5.15"
     "@feathersjs/feathers" "^4.5.15"
     "@feathersjs/rest-client" "^4.5.15"
@@ -20,32 +19,32 @@
     yup "^1.0.0-beta.8"
     zod "^3.22.1"
 
-"@adaptable/cloud@1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-1.26.0.tgz#2acfd7c59c7df52e9bee42bbba8582709e790004"
-  integrity sha512-54lORrXgTFGWtaONBvRQaJKUexoYbpoN+2kSligwgecpA8bhM+OBgmosawp8Z4ZgZa4B8gCkeCXoZL0/V9QlHw==
+"@adaptable/cloud@1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/cloud/-/cloud-1.27.0.tgz#c6747c55a40945a9766e78504d22960b9c11134d"
+  integrity sha512-JUp5v/aXBhlrX3Qx8Y6h6t3i7bbHpm4yp6TdRaEqE1A0fxqmSgTDlLqRdHp/8BvawfxSwPK/vce6Oqodqc3gtQ==
   dependencies:
-    "@adaptable/client" "1.26.0"
-    "@adaptable/utils" "1.26.0"
+    "@adaptable/client" "1.27.0"
+    "@adaptable/utils" "1.27.0"
     "@adpt/utils" "^0.4.0-next.25"
     fast-deep-equal "^3.1.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.21"
 
-"@adaptable/template@1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.26.0.tgz#714fc49a8f9d905ded951e31e684a300fb026b73"
-  integrity sha512-fD6ie0HE5KD2SAcGT2OHXWEt+IkQPOZeGoR5taDxX51AkOBZeHwSGG6/fSTGNIXFg24k/KNqoWvMcTrQCYuK0g==
+"@adaptable/template@1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/template/-/template-1.27.0.tgz#a82e4e2ac0c8af2383b781d625d6e6946b919fa4"
+  integrity sha512-w25kJ7RTOM66XEBq9eFQjRtuxG4rDf2DBbelEBMP6dz55sVO5FrceEfb6WXNXySMxl5d2f6KB+snVKX7+lDPbA==
   dependencies:
-    "@adaptable/utils" "1.26.0"
+    "@adaptable/utils" "1.27.0"
     dotenv "^8.2.0"
     js-yaml "^3.14.0"
     json5 "^2.1.3"
 
-"@adaptable/utils@1.26.0":
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.26.0.tgz#c30cf3370e663d78a65a832654c12535bf79ac41"
-  integrity sha512-7MhUT+iIAlXglToIeihOlsLEO37mPU2Nr+G9tLLKZPi557svy/ZwSh8K1Y+5rbCPQ5r2QsxKuZCW/e9oL4myHw==
+"@adaptable/utils@1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@adaptable/utils/-/utils-1.27.0.tgz#dd87ac7b3cea42d1ed7ec52770ae6d0010197053"
+  integrity sha512-kJjglcjluo5KekgUSaG/8qvnj3XQH32+MpbgnmYaEG+6ghchvZSKn2ZfWV93atvf3nkDIK8Kdgg9BfILDmM2gA==
   dependencies:
     "@feathersjs/feathers" "^4.5.15"
     ajv "^8.12.0"
@@ -143,39 +142,6 @@
     ts-custom-error "3.2.0"
     tslib "2.0.3"
     xml2js "0.4.23"
-
-"@adpt/utils@0.4.0-next.25":
-  version "0.4.0-next.25"
-  resolved "https://registry.yarnpkg.com/@adpt/utils/-/utils-0.4.0-next.25.tgz#8f425e10f5026b3fa8bd9a8255a916760e8a08a1"
-  integrity sha512-PX0gj52w9sGW9PTzh1tmlusEcHA1YmICMdRiYp4C+B0RtFLHlUe1vKuZT9e1sdgbUmhyY3M90mCj7gkQjs2A6w==
-  dependencies:
-    "@types/debug" "4.1.5"
-    "@types/fs-extra" "8.1.1"
-    "@types/jju" "1.4.1"
-    "@types/tar" "4.0.4"
-    "@unboundedsystems/node-graceful" "3.0.0-unb.2"
-    "@usys/collections-ts" "0.0.2"
-    capture-exit "2.0.0"
-    debug "4.3.1"
-    decamelize "4.0.0"
-    deep-diff "1.0.2"
-    eventemitter2 "6.4.3"
-    execa "5.0.0"
-    find-up "5.0.0"
-    fs-extra "9.0.1"
-    global-dirs "2.0.1"
-    jju "1.4.0"
-    json-stable-stringify "1.0.1"
-    json5-with-undefined "2.1.301"
-    lodash "4.17.20"
-    node-fetch "2.6.1"
-    npm-run-path "4.0.1"
-    p-defer "3.0.0"
-    tar "6.0.5"
-    ts-custom-error "3.2.0"
-    tslib "2.0.3"
-    type-ops "3.0.3"
-    yarn "1.22.10"
 
 "@adpt/utils@0.4.0-next.26", "@adpt/utils@^0.4.0-next.25", "@adpt/utils@^0.4.0-next.26":
   version "0.4.0-next.26"


### PR DESCRIPTION
> **NOTE:**  https://github.com/adaptable/io/pull/1124 must be merged first and this PR must be updated with the newer versions of `@adaptable/cloud`.

This PR works with https://github.com/adaptable/io/pull/1124. It sets the `IMAGE_WORKSPACE_DIR` environment variable so that it is available during Adapt runtime for computation of the root cert path.

It also adds the database root cert to the system certs for Nixpacks. Note that this is not sufficient for older versions of the `pg` node module, but it may be helpful for other clients.